### PR TITLE
Snap

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,3 +1,7 @@
+const DEBUG_MODE = false;
+
+const GRID_SPACING = 20;
+
 const COLORS = {
 	DRAWING: {
 		BLACK: "rgba(0, 0, 0, 0.5)",

--- a/sketch.js
+++ b/sketch.js
@@ -174,8 +174,8 @@ function snap(point) {
 }
 
 function drawGrid() {
-  for (let i = 0; i < width; i += SNAP_TO) {
-    for (let j = 0; j < height; j += SNAP_TO) {
+  for (let i = 0; i < width; i += GRID_SPACING) {
+    for (let j = 0; j < height; j += GRID_SPACING) {
       fill(COLORS.DRAWING.BLACK);
       circle(i, j, 1);
     }

--- a/sketch.js
+++ b/sketch.js
@@ -64,8 +64,8 @@ function draw() {
     }else if(mode == MODE.ENDPOINTS){
       addRect(endPoints);
     }else if(mode == MODE.PLAYER_START){
-      playerStartX = mouseX;
-      playerStartY = mouseY; 
+      playerStartX = snap(mouseX);
+      playerStartY = snap(mouseY); 
     }
     
     mouseDown = false;
@@ -119,7 +119,7 @@ function draw() {
   }
   
   
-  
+  if (DEBUG_MODE) drawGrid();
 }
 
 function keyPressed() {
@@ -158,17 +158,29 @@ function drawRectToCursor(color) {
   let w = mouseX - rectX;
   let h = mouseY - rectY;
   fill(color);
-  rect(rectX, rectY, w, h);
+  rect(snap(rectX), snap(rectY), snap(w), snap(h));
 }
 
 function addRect(a) {
   let w = endX - rectX;
   let h = endY - rectY;
 
-  a.push(new Rectangle(rectX, rectY, w, h));
+  a.push(new Rectangle(snap(rectX), snap(rectY), snap(w), snap(h)));
 }
 
+function snap(point) {
+  let delta = point % GRID_SPACING;
+  return delta > GRID_SPACING/2 ? point + (GRID_SPACING - delta) : point - delta;
+}
 
+function drawGrid() {
+  for (let i = 0; i < width; i += SNAP_TO) {
+    for (let j = 0; j < height; j += SNAP_TO) {
+      fill(COLORS.DRAWING.BLACK);
+      circle(i, j, 1);
+    }
+  }
+}
 
 function mousePressed() {
   rectX = mouseX;


### PR DESCRIPTION
# Snap to grid

## Changes

+ Created the function `snap` that takes a point and snaps it to a grid. The spacing is defined by `GRID_SPACING` in `constants.js`. It only takes a single point rather than an (x, y) coordinate pair since the x point to snap to is independent of the y point, and vice versa.

+ Added an overlay of a grid of single points in `DEBUG_MODE`.

## How does `snap` work?

```
function snap(point) {
   let delta = point % GRID_SPACING; 
   return delta > GRID_SPACING/2 ? point + (GRID_SPACING - delta) : point - delta;
 }
```

The first line gets the difference (`delta`) between the given point and the closest grid unit. Since it its using modulo to determine the `delta`, it would always round down. For example, snapping `127` to a grid with spacing of `10` would result in `127 % 10 = 7`, so the closest point would be `120`. To get the actual closest grid point (`130` in the example) check if the `delta` is greater than half the `GRID_SPACING`, and if so add the different between the `delta` and `GRID_SPACING` instead of subtracting it.

### Full Examples
`123` in to grid of `10`
```
GRID_SPACING = 10
point = 123
delta = point % GRID_SPACING = 3
delta < GRID_SPACING/2
point - delta = 120 
```
`127` in to grid of `10`
```
GRID_SPACING = 10
point = 127
delta = point % GRID_SPACING = 7
delta > GRID_SPACING/2
GRID_SPACING - DELTA = 3
point + 3 = 130 
```

## Demo
*With `DEBUG_MODE = true`*

https://github.com/jakefortay/Level-Builder/assets/23586048/d987b656-3778-467c-b626-f8a206345080
